### PR TITLE
[#50] 버튼 컴포넌트 내 아이콘 컬러, 커스텀 클래스네임 props 추가

### DIFF
--- a/src/components/button/basic-button.tsx
+++ b/src/components/button/basic-button.tsx
@@ -9,11 +9,14 @@ import {
   ButtonState,
   ButtonTextColor,
 } from "./style";
-import Icon from "../icon/icon";
+import Icon, { iconVariants } from "../icon/icon";
 import type { IconName } from "../icon/icon-map";
+import type { VariantProps } from "class-variance-authority";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: IconName;
+  iconClassName?: string;
+  iconColor?: VariantProps<typeof iconVariants>["color"];
   appearance?: ButtonState;
   label?: string;
   shape?: ButtonShape;
@@ -25,6 +28,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const Button = ({
   appearance = "default",
   icon,
+  iconColor,
+  iconClassName,
   label,
   className,
   children,
@@ -40,7 +45,13 @@ const Button = ({
       )}
       {...props}
     >
-      {icon && <Icon icon={icon} />}
+      {icon && (
+        <Icon
+          icon={icon}
+          className={iconClassName}
+          color={iconColor ?? "default"}
+        />
+      )}
       <span className={BUTTON_TEXT_COLOR_VARIANTS[appearance]}>{label}</span>
       {children}
     </button>

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { VariantProps, cva } from "class-variance-authority";
 import ICON_MAP from "./icon-map";
 
-const iconVariants = cva("inline-block", {
+export const iconVariants = cva("inline-block", {
   variants: {
     color: {
       default: "",


### PR DESCRIPTION
<!-- PR 제목은 '[#이슈번호] 작업 내용 요약'으로 통일해주세요. -->

## 📄 PR 내용 요약
아이콘과 함께 사용되는 버튼 컴포넌트에 아이콘 컬러와 커스텀 클래스 prop을 추가해 스타일 변경이 가능하도록 개선

## ✅ 작업 내용 상세
컬러 및 커스텀 클래스 props 추가

## 📸 스크린샷 (선택사항)

## 💬 참고 사항