### PR TITLE
[#81] 리뷰 등록 모달 관련 작업 및 리뷰 등록 로직 일부분 작업

### DIFF
--- a/src/api/reviews/post-review.ts
+++ b/src/api/reviews/post-review.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { ReviewFormData } from "@/app/wines/[id]/_types";
+
+export default async function postReview(data: ReviewFormData) {
+  const token = process.env.NEXT_PUBLIC_TEST_TOKEN;
+
+  const response = await axios.post(
+    `${process.env.NEXT_PUBLIC_API_URL}/reviews`,
+    data,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  return response.data;
+}

--- a/src/app/wines/[id]/_components/review-form.tsx
+++ b/src/app/wines/[id]/_components/review-form.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import WineTaste from "@/components/wine-taste/wine-taste";
+import StarRating from "@/components/star-rating/star-rating";
+import Button from "@/components/button/basic-button";
+import Chip from "@/components/chip/chip";
+import { aromaMap } from "@/components/flavor/aroma-map";
+import { AromaKey } from "@/types/AromaType";
+import { GaugeLevel } from "@/components/gauge/block-gauge";
+import { getTasteDescription } from "@/components/wine-taste/_utils/tasteUtils";
+import WineInfo from "./wine-info";
+import type { ReviewFormData } from "../_types";
+
+interface ReviewFormProps {
+  wineId: number;
+  wineName: string;
+  wineRegion: string;
+  wineImage: string;
+  onSubmit: (data: ReviewFormData) => void;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+}
+
+export default function ReviewForm({
+  wineId,
+  wineName,
+  wineRegion,
+  wineImage,
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+}: ReviewFormProps) {
+  const [rating, setRating] = useState(0);
+  const [content, setContent] = useState("");
+  const [tastes, setTastes] = useState([
+    { type: "바디감", data: 0 as GaugeLevel, taste: "없음" },
+    { type: "탄닌", data: 0 as GaugeLevel, taste: "없음" },
+    { type: "당도", data: 0 as GaugeLevel, taste: "없음" },
+    { type: "산미", data: 0 as GaugeLevel, taste: "없음" },
+  ]);
+
+  const handleTasteChange = (index: number, newLevel: GaugeLevel) => {
+    const newTastes = [...tastes];
+    newTastes[index].data = newLevel;
+    newTastes[index].taste = getTasteDescription(
+      newTastes[index].type,
+      newLevel
+    );
+    setTastes(newTastes);
+  };
+
+  const handleSubmit = () => {
+    const reviewData: ReviewFormData = {
+      rating,
+      lightBold: tastes[0].data,
+      smoothTannic: tastes[1].data,
+      drySweet: tastes[2].data,
+      softAcidic: tastes[3].data,
+      aroma: [],
+      content,
+      wineId,
+    };
+
+    onSubmit(reviewData);
+  };
+
+  const aromaKeys = (Object.keys(aromaMap) as AromaKey[]).filter(
+    (key) => key !== "EMPTY"
+  );
+
+  return (
+    <div className="flex w-full max-w-[480px] flex-col">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between pb-8">
+        <h2 className="text-heading-lg">리뷰 등록</h2>
+        <button
+          onClick={onCancel}
+          className="text-2xl leading-none text-gray-400 hover:text-gray-600"
+          aria-label="닫기"
+          type="button"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* 모든 컨텐츠 */}
+      <div className="flex flex-col gap-8">
+        {/* 와인 정보 */}
+        <div>
+          <WineInfo name={wineName} region={wineRegion} image={wineImage} />
+          <div className="mt-4 border-t border-gray-300" />
+        </div>
+
+        {/* 별점 선택 */}
+        <div className="flex items-center gap-4">
+          <label className="text-body-sm text-gray-500">별점 선택</label>
+          <StarRating rating={rating} size="lg" />
+        </div>
+
+        {/* 후기 입력 */}
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="후기를 작성해주세요."
+          className="h-32 w-full resize-none rounded-lg border border-gray-300 p-3 focus:outline-none focus:ring-2 focus:ring-primary"
+          maxLength={500}
+        />
+
+        {/* 와인의 맛 */}
+        <div>
+          <label className="mb-4 block text-heading-md">
+            와인의 맛은 어땠나요?
+          </label>
+          <WineTaste
+            type="detail"
+            tastes={tastes}
+            onChange={handleTasteChange}
+          />
+        </div>
+
+        {/* 향 선택 */}
+        <div>
+          <label className="mb-4 block text-heading-md">
+            기억에 남는 향이 있나요?
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {aromaKeys.map((aroma) => (
+              <Chip key={aroma} label={aromaMap[aroma].label} />
+            ))}
+          </div>
+        </div>
+
+        {/* 버튼 */}
+        <Button
+          onClick={handleSubmit}
+          label={isSubmitting ? "리뷰 남기는 중" : "리뷰 남기기"}
+          disabled={isSubmitting || rating === 0 || !content.trim()}
+          className="w-full"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/wines/[id]/_components/wine-info.tsx
+++ b/src/app/wines/[id]/_components/wine-info.tsx
@@ -9,7 +9,7 @@ interface WineInfoProps {
 export default function WineInfo({ name, region, image }: WineInfoProps) {
   return (
     <div className="flex items-center gap-4">
-      <div className="flex h-[96px] w-[62px] flex-shrink-0 items-center justify-center rounded bg-gray-200">
+      <div className="flex-center h-[96px] w-[62px] flex-shrink-0 rounded bg-gray-200">
         {image ? (
           <Image
             src={image}

--- a/src/app/wines/[id]/_components/wine-info.tsx
+++ b/src/app/wines/[id]/_components/wine-info.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+interface WineInfoProps {
+  name: string;
+  region: string;
+  image?: string;
+}
+
+export default function WineInfo({ name, region, image }: WineInfoProps) {
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex h-[96px] w-[62px] flex-shrink-0 items-center justify-center rounded bg-gray-200">
+        {image ? (
+          <Image
+            src={image}
+            alt={name}
+            width={62}
+            height={96}
+            className="h-full w-auto object-contain"
+          />
+        ) : (
+          <span className="text-xs text-gray-400">No Image</span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="text-body-md font-bold text-gray-900">{name}</h3>
+        <p className="text-body-sm text-gray-500">{region}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/wines/[id]/_hooks/use-review-submit.ts
+++ b/src/app/wines/[id]/_hooks/use-review-submit.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import postReview from "@/api/reviews/post-review";
+import type { ReviewFormData } from "../_types";
+
+/**
+ * 리뷰 제출을 처리하는 TanStack Query Mutation 훅
+ * @author junyeol
+ * @returns {Object} mutation 객체
+ * @returns {Function} mutation.mutate - 리뷰 제출 함수 (콜백 방식)
+ * @returns {Function} mutation.mutateAsync - 리뷰 제출 함수 (Promise 방식)
+ * @returns {boolean} mutation.isPending - 제출 중 상태
+ * @returns {boolean} mutation.isSuccess - 제출 성공 여부
+ * @returns {boolean} mutation.isError - 에러 발생 여부
+ * @returns {Error | null} mutation.error - 에러 객체
+ *
+ * @example
+ * const { mutate, isPending } = useReviewSubmit();
+ *
+ * mutate(reviewData, {
+ *   onSuccess: () => alert('성공!'),
+ *   onError: (err) => alert('실패!')
+ * });
+ */
+
+export function useReviewSubmit() {
+  const queryClient = useQueryClient();
+
+  const { mutate, mutateAsync, isPending, isSuccess, isError, error } =
+    useMutation({
+      mutationFn: (data: ReviewFormData) => postReview(data),
+
+      onSuccess: (responseData, variables) => {
+        queryClient.invalidateQueries({
+          queryKey: ["reviews", variables.wineId],
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: ["wine", variables.wineId],
+        });
+      },
+
+      onError: (error: any) => {
+        console.error("리뷰 등록 실패:", error);
+      },
+    });
+
+  return {
+    mutate,
+    mutateAsync,
+    isPending,
+    isSuccess,
+    isError,
+    error,
+  };
+}

--- a/src/app/wines/[id]/_types/index.ts
+++ b/src/app/wines/[id]/_types/index.ts
@@ -1,0 +1,25 @@
+import { AromaKey } from "@/types/AromaType";
+
+/**
+ * ReviewForm 컴포넌트에서 사용되는 폼 데이터 타입
+ * @author junyeol
+ * @property rating - 별점 (0 ~ 5)
+ * @property lightBold - 바디감 (0 ~ 6)
+ * @property smoothTannic - 탄닌 (0 ~ 6)
+ * @property drySweet - 당도 (0 ~ 6)
+ * @property softAcidic - 산미 (0 ~ 6)
+ * @property aroma - 향 배열 (예: ["CHERRY", "BERRY"])
+ * @property content - 리뷰 내용
+ * @property windId - 해당하는 와인 ID
+ */
+
+export interface ReviewFormData {
+  rating: number;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+  aroma: AromaKey[];
+  content: string;
+  wineId: number;
+}

--- a/src/app/wines/[id]/page.tsx
+++ b/src/app/wines/[id]/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, use, useEffect, useRef } from "react";
+import Button from "@/components/button/basic-button";
+import Modal from "@/components/modal/modal";
+import ReviewForm from "./_components/review-form";
+import { useReviewSubmit } from "./_hooks/use-review-submit";
+import { lockingScroll, allowScroll } from "@/lib/utils";
+
+/**
+ * 와인 상세 페이지
+ * @author junyeol
+ */
+export default function WineDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const wineId = Number(id);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const { mutate, isPending } = useReviewSubmit();
+
+  useEffect(() => {
+    if (!dialogRef.current) return;
+
+    if (isModalOpen && !dialogRef.current.open) {
+      dialogRef.current.showModal();
+      lockingScroll();
+    } else if (!isModalOpen && dialogRef.current.open) {
+      dialogRef.current.close();
+      allowScroll();
+    }
+  }, [isModalOpen]);
+
+  const handleSubmit = (reviewData: any) => {
+    mutate(reviewData, {
+      onSuccess: () => {
+        alert("리뷰가 성공적으로 등록되었습니다!");
+        setIsModalOpen(false);
+      },
+      onError: (error: any) => {
+        alert(`리뷰 등록 실패: ${error.message || "알 수 없는 오류"}`);
+      },
+    });
+  };
+
+  const handleClose = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        <div className="mb-8 rounded-lg bg-white p-6 shadow">
+          <h1 className="mb-2 text-3xl font-bold">와인 이름 (ID: {wineId})</h1>
+        </div>
+
+        <div className="rounded-lg bg-white p-6 shadow">
+          <div className="mb-6 flex items-center justify-between">
+            <Button
+              onClick={() => setIsModalOpen(true)}
+              label="리뷰 작성하기"
+            />
+          </div>
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <Modal
+          ref={dialogRef}
+          onCancel={handleClose}
+          className="!flex max-h-[90vh] w-full max-w-[520px] !flex-col !items-start !justify-start overflow-y-auto px-8 py-8"
+        >
+          <ReviewForm
+            wineId={wineId}
+            wineName="Sentinel Carbernet Sauvignon 2016"
+            wineRegion="Western Cape, South Africa"
+            wineImage=""
+            onSubmit={handleSubmit}
+            onCancel={handleClose}
+            isSubmitting={isPending}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/app/wines/[id]/page.tsx
+++ b/src/app/wines/[id]/page.tsx
@@ -55,7 +55,7 @@ export default function WineDetailPage({
     <div className="min-h-screen bg-gray-50">
       <div className="mx-auto max-w-7xl px-4 py-8">
         <div className="mb-8 rounded-lg bg-white p-6 shadow">
-          <h1 className="mb-2 text-3xl font-bold">와인 이름 (ID: {wineId})</h1>
+          <h1 className="mb-2 text-title-hero">와인 이름 (ID: {wineId})</h1>
         </div>
 
         <div className="rounded-lg bg-white p-6 shadow">
@@ -72,7 +72,7 @@ export default function WineDetailPage({
         <Modal
           ref={dialogRef}
           onCancel={handleClose}
-          className="!flex max-h-[90vh] w-full max-w-[520px] !flex-col !items-start !justify-start overflow-y-auto px-8 py-8"
+          className="!flex max-h-[90vh] max-w-[520px] !flex-col !items-start !justify-start overflow-y-auto px-8 py-8"
         >
           <ReviewForm
             wineId={wineId}


### PR DESCRIPTION
## 📄 PR 내용 요약

- 와인 상세페이지에 해당하는 리뷰 등록하기 버튼에 대한 리뷰 등록 모달 작업
- 리뷰 등록 모달에 들어갈 컴포넌트 디자인 작업
- 리뷰 등록을 위한 일부 로직 구현

## ✅ 작업 내용 상세

- 휘태님이 작업하신 모달 컴포넌트를 가져와 리뷰 등록을 위한 컴포넌트와 api 일부를 구현하였습니다.

- modal 컴포넌트의 기본스타일로 인해 이번에 만든 리뷰 등록 컴포넌트의 스타일이 적용이 안돼 오버라이드 방식으로 강제로 적용해놨습니다..
이 부분은 나중에 모달별로 스타일 props를 받는다면 수정이 가능할 것 같습니다.

- 피그마 시안에 해당하는 하단 버튼과 버튼상단의 블러같은 경우는 리뷰 등록 컴포넌트 자체에서는 구현이 불가능한 것 같습니다.
이것 저것 시도는 해보았는데 적용이 잘 안되네요 이것 또한 모달 컴포넌트에 footer prop으로 영역을 분리해서 적용하는 건 어떨까 싶습니다.

- 별점 선택 기능은 현재 읽기 전용으로 컴포넌트가 구현되어있어서 보여주기용으로 적용을 해놨습니다.

- 향 선택 기능도 별점 선택 기능과 동일하게 읽기 전용으로 넣어뒀습니다.

- 테스트를 하기위해 .env.local 파일을 만들어 환경변수를 사용했습니다.
혹시 테스트 해보실 분들은 swagger에서 로그인 api 호출후 토큰을 받아와서 .env.local 파일을 만들어 저장 후 테스트 하시면 될 것 같습니다.

- 반응형은 아직 구현하지않고 pc 기준으로만 만들었습니다.

## 📸 스크린샷 (선택사항)

<img width="662" height="876" alt="스크린샷 2025-10-03 20 46 13" src="https://github.com/user-attachments/assets/81c99405-ea9f-4cc3-b77c-f899fdba82c1" />

## 💬 참고 사항

- 혹시 코드나 파일 구조에 있어서 문제가 있다면 피드백 부탁드립니다!
  처음해보는 작업이라 검색과 AI와 함께 작업을 했습니다..

