### PR TITLE
[#X] 회원가입 성공 후 메인페이지로 이동되지 않는 버그 수정

### DIFF
--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -13,7 +13,7 @@ const opts = {
 const login = async (prevState: any, formData: FormData) => {
   const email = formData.get("email");
   const password = formData.get("password");
-  const redirectUrl = formData.get("redirect");
+  const redirectUrl = formData.get("redirect") || "/";
 
   if (!email || !password)
     return { isError: true, message: "이메일 또는 비밀번호를 입력하세요." };

--- a/src/api/auth/signup-action.ts
+++ b/src/api/auth/signup-action.ts
@@ -33,11 +33,9 @@ const signup = async (prevState: any, formData: FormData) => {
     formData.append("email", email);
     formData.append("password", password);
 
-    const loginResult = await login(prevState, formData);
-
-    return loginResult;
+    await login(prevState, formData);
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -31,7 +31,7 @@ const Page = () => {
 
   useEffect(() => {
     if (state && !state.isError) {
-      router.push("/");
+      window.location.href = "/";
       signupSuccess();
     } else if (state && state.isError) {
       signupError();

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -9,7 +9,6 @@ import { useForm } from "react-hook-form";
 import REGEX from "@/constants/regex";
 import { useActionState, useEffect } from "react";
 import signup from "@/api/auth/signup-action";
-import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
 
 interface SignupFormData {
@@ -25,7 +24,6 @@ const Page = () => {
     getValues,
     formState: { errors, isValid },
   } = useForm<SignupFormData>();
-  const router = useRouter();
   const { signupSuccess, signupError } = useToast();
   const [state, formAction, isPending] = useActionState(signup, null);
 


### PR DESCRIPTION
<!-- PR 제목은 '[#이슈번호] 작업 내용 요약'으로 통일해주세요. -->

## 📄 PR 내용 요약
회원가입 성공 후 메인페이지로 리다이렉트 합니다

## ✅ 작업 내용 상세
회원가입을 완료한 후 로그인 된 상태로 메인페이지로 리다이렉트 되지 않는 현상을 수정했습니다.

원인
- `login.ts`의 `redirect()`함수는 리다이렉트를 위해 에러를 반환합니다.
  `signup.ts`의 로직은 회원가입이 완료된 후 로그인을 진행하도록 했는데 `redirect()`에서 반환되는 에러를 `catch()`로 잡아버려서 리다이렉트가 되지 않은 것으로 추측하고 있습니다.

## 📸 스크린샷 (선택사항)

## 💬 참고 사항
